### PR TITLE
🔧 Add .envrc to work with local Bindl, environment variables

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,5 @@
+# Add local bin/ to PATH. 
+PATH_add bin
+
+# Also load in variables from the .env file.
+dotenv


### PR DESCRIPTION
## What this PR does / Why we need it

Primarily to add the local `bin/` directory into the `$PATH`. This way the tools that are installed locally by Bindl can be called directly from commandline.

## Which issue(s) this PR fixes

Development workflow.
