### PR TITLE
🔧 Disable functional and integration tests for now

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -13,8 +13,8 @@ jobs:
       matrix:
         tests:
         - unit
-        - integration
-        - functional
+        # - integration
+        # - functional
     steps:
     - uses: actions/checkout@v3
 

--- a/Makefile
+++ b/Makefile
@@ -55,14 +55,14 @@ run: rebuild
 test/unit: gomod
 	${GO} test -race -short -v ./...
 
-.PHONY: test/integration
-test/integration: gomod
-	${GO} test -race -run ".*[Ii]ntegration.*" -v ./...
-
-.PHONY: test/functional
-test/functional: gomod
-	PATH=${PWD}/bin:${PATH} ${MAKE} bin/snippets
-	PATH=${PWD}/bin:${PATH} ${GO} test -race -run ".*[Ff]unctional.*" -v ./...
+# .PHONY: test/integration
+# test/integration: gomod
+# 	${GO} test -race -run ".*[Ii]ntegration.*" -v ./...
+#
+# .PHONY: test/functional
+# test/functional: gomod
+# 	PATH=${PWD}/bin:${PATH} ${MAKE} bin/snippets
+# 	PATH=${PWD}/bin:${PATH} ${GO} test -race -run ".*[Ff]unctional.*" -v ./...
 
 .PHONY: test/all
 test/all: gomod


### PR DESCRIPTION
## What this PR does / Why we need it

Since there aren't any functional or integration tests right now, these tests [fail](https://github.com/chrisyxlee/snippets/runs/7085370292?check_suite_focus=true).
