### PR TITLE
🌱 Add util package for assert, time parsing, value pointers, and fix ratelimit race

### DIFF
--- a/internal/ratelimit/rate_limit_test.go
+++ b/internal/ratelimit/rate_limit_test.go
@@ -18,13 +18,10 @@ func TestRateLimit(t *testing.T) {
 	ratelimit.SetClock(mc)
 
 	t.Run("not rate limited", func(t *testing.T) {
-		t.Parallel()
-
 		assert.False(t, ratelimit.WaitIfRateLimited(fmt.Errorf("blah")))
 	})
 
 	t.Run("rate limit time already passed", func(t *testing.T) {
-		t.Parallel()
 		assert.True(t, ratelimit.WaitIfRateLimited(&github.RateLimitError{
 			Rate: github.Rate{
 				Limit:     100,
@@ -37,8 +34,6 @@ func TestRateLimit(t *testing.T) {
 	})
 
 	t.Run("rate limited", func(t *testing.T) {
-		t.Parallel()
-
 		mc := clock.NewMock()
 		ratelimit.SetClock(mc)
 

--- a/internal/util/assert.go
+++ b/internal/util/assert.go
@@ -1,0 +1,11 @@
+package util
+
+import "fmt"
+
+// Assert checks a condition and panics if it's false. If the condition is true,
+// this function does nothing.
+func Assert(condition bool, detail string, args ...any) {
+	if !condition {
+		panic(fmt.Sprintf(detail, args...))
+	}
+}

--- a/internal/util/assert_test.go
+++ b/internal/util/assert_test.go
@@ -1,0 +1,18 @@
+package util_test
+
+import (
+	"testing"
+
+	"github.com/chrisyxlee/snippets/internal/util"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestXxx(t *testing.T) {
+	assert.Panics(t, func() {
+		util.Assert(false, "some output")
+	})
+
+	assert.NotPanics(t, func() {
+		util.Assert(true, "yay")
+	})
+}

--- a/internal/util/time.go
+++ b/internal/util/time.go
@@ -1,0 +1,44 @@
+package util
+
+import "time"
+
+const (
+	Week = time.Hour * 24 * 7
+)
+
+const (
+	TimeLayout = "2006-01-02 15:04"
+	DateLayout = "Jan 2"
+)
+
+// FormatLocalTime formats the time in the local timezone with minute granularity.
+func FormatLocalTime(t time.Time) string {
+	return t.Local().Format(TimeLayout)
+}
+
+// ParseLocalTime parses time in the format defined by TimeLayout. The output of
+// FormatLocalTime should be able to be parsed with no errors.
+func ParseLocalTime(timeStr string) (time.Time, error) {
+	return time.ParseInLocation(TimeLayout, timeStr, time.Local)
+}
+
+// ParseLocalTimeOrDie parses time in the format defined by TimeLayout. On error,
+// this function will panic. The output of FormatLocalTime should be able to be parsed
+// without dying.
+func ParseLocalTimeOrDie(timeStr string) time.Time {
+	t, err := ParseLocalTime(timeStr)
+	Assert(err == nil, "Failed to parse time, wanted layout `%s`, got `%s`",
+		TimeLayout, timeStr)
+	return t
+}
+
+// FormatLocalDate formats time in the local time zone with day granularity and does not
+// display the year.
+func FormatLocalDate(t time.Time) string {
+	return t.Local().Format(DateLayout)
+}
+
+// InTimeRange returns true if the time t is within the range [start, end).
+func InTimeRange(t time.Time, start time.Time, end time.Time) bool {
+	return !t.Before(start) && t.Before(end)
+}

--- a/internal/util/time_test.go
+++ b/internal/util/time_test.go
@@ -1,0 +1,44 @@
+package util_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/chrisyxlee/snippets/internal/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTime(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().Truncate(time.Minute)
+	formatted := util.FormatLocalTime(now)
+
+	got, err := util.ParseLocalTime(formatted)
+	assert.NoError(t, err)
+	assert.Equal(t, now, got)
+
+	assert.NotPanics(t, func() {
+		got = util.ParseLocalTimeOrDie(formatted)
+	})
+	assert.Equal(t, now, got)
+}
+
+func TestInTimeRange(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+
+	assert.True(t, util.InTimeRange(now, now, now.Add(time.Minute)))
+	assert.True(t, util.InTimeRange(now, now.Add(-time.Minute), now.Add(time.Second)))
+	assert.False(t, util.InTimeRange(now, now.Add(-time.Minute), now))
+}
+
+func TestDate(t *testing.T) {
+	t.Parallel()
+
+	parsed, err := time.ParseInLocation("2006-01-02", "2222-12-30", time.Local)
+	require.NoError(t, err)
+	assert.Equal(t, "Dec 30", util.FormatLocalDate(parsed))
+}

--- a/internal/util/value.go
+++ b/internal/util/value.go
@@ -1,0 +1,5 @@
+package util
+
+func NewValue[T comparable](v T) *T {
+	return &v
+}

--- a/internal/util/value_test.go
+++ b/internal/util/value_test.go
@@ -1,0 +1,16 @@
+package util_test
+
+import (
+	"testing"
+
+	"github.com/chrisyxlee/snippets/internal/util"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewValue(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, int64(0), *util.NewValue(int64(0)))
+	assert.Equal(t, "bleh", *util.NewValue("bleh"))
+	assert.InDelta(t, float64(0.123), *util.NewValue(float64(0.123)), 0.00001)
+}


### PR DESCRIPTION
## What this PR does / Why we need it

Adds a util package with assertion, time/date parsing, and a function to convert a value into a pointer.

Also fixes an error where the ratelimit package was using the same clock and causing a race when I run the tests in parallel. :(