### PR TITLE
✨ Handle GitHub API pagination with rate limit

### DIFF
--- a/internal/page/paginate.go
+++ b/internal/page/paginate.go
@@ -1,0 +1,46 @@
+package page
+
+import (
+	"github.com/chrisyxlee/snippets/internal"
+	"github.com/chrisyxlee/snippets/internal/ratelimit"
+	"github.com/google/go-github/v45/github"
+)
+
+// Details are options that the caller can return to describe how to proceed
+// with pagination.
+type Details struct {
+	// Whether pagination should stop now at the caller's request.
+	StopEarly bool
+}
+
+// Paginate handles pagination according to the google/go-github API. It handles the
+// rate limit error by waiting if it receives one. This allows the caller to handle
+// just the business logic without having to worry about pagination. The details the
+// caller can return control whether the function returns early.
+func Paginate(detail string, perPage int, fn func(listOptions github.ListOptions) (Details, *github.Response, error)) error {
+	pageNum := 1
+	for {
+		internal.Log().Debug().Int("items", perPage).Int("page", pageNum).Str("detail", detail).Msgf("paginating")
+
+		options := github.ListOptions{
+			PerPage: perPage,
+			Page:    pageNum,
+		}
+
+		details, resp, err := fn(options)
+		if ratelimit.WaitIfRateLimited(err) {
+			// Don't increase the page number since we were rate limited and need to try the request again.
+			continue
+		}
+
+		if err != nil {
+			return err
+		}
+
+		if details.StopEarly || resp.LastPage == pageNum {
+			return nil
+		}
+
+		pageNum = resp.NextPage
+	}
+}

--- a/internal/page/paginate_test.go
+++ b/internal/page/paginate_test.go
@@ -1,0 +1,66 @@
+package page_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/chrisyxlee/snippets/internal/page"
+	"github.com/google/go-github/v45/github"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStopEarly(t *testing.T) {
+	testCount := 0
+	assert.NoError(t, page.Paginate("test", 10, func(listOptions github.ListOptions) (page.Details, *github.Response, error) {
+		testCount++
+
+		if listOptions.Page == 2 {
+			return page.Details{
+				StopEarly: true,
+			}, &github.Response{}, nil
+		}
+
+		return page.Details{}, &github.Response{
+			NextPage: listOptions.Page + 1,
+			LastPage: 3,
+		}, nil
+	}))
+	assert.Equal(t, 2, testCount)
+}
+
+func TestUntilLastPageWithRateLimitOnEveryCall(t *testing.T) {
+	testCount := 0
+	totalPages := 3
+	visited := make(map[int]bool)
+	assert.NoError(t, page.Paginate("test", 10, func(listOptions github.ListOptions) (page.Details, *github.Response, error) {
+		testCount++
+
+		if visited[listOptions.Page] {
+			return page.Details{}, &github.Response{
+				NextPage: listOptions.Page + 1,
+				LastPage: totalPages,
+			}, nil
+		}
+
+		visited[listOptions.Page] = true
+		return page.Details{}, &github.Response{
+				NextPage: listOptions.Page + 1,
+				LastPage: totalPages,
+			}, &github.RateLimitError{
+				Rate: github.Rate{
+					Reset: github.Timestamp{
+						Time: time.Now().Add(-5 * time.Minute),
+					},
+				},
+			}
+	}))
+	// Each page should be visited twice because of the rate limit.
+	assert.Equal(t, totalPages*2, testCount)
+}
+
+func TestPassAlongError(t *testing.T) {
+	assert.Error(t, page.Paginate("test", 10, func(listOptions github.ListOptions) (page.Details, *github.Response, error) {
+		return page.Details{}, &github.Response{}, fmt.Errorf("some error")
+	}))
+}


### PR DESCRIPTION
## What this PR does / Why we need it

Make it easy to handle pagination without having to duplicate code for every call to the GitHub API.